### PR TITLE
Changed release URL from BLHeli to JESC

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This software is provided as is, use it at your own risk. **ALWAYS REMOVE THE PR
 
 ### Standalone
 
-Download the appropriate installer for your platform from [Releases](https://github.com/blheli-configurator/blheli-configurator/releases).
+Download the appropriate installer for your platform from [Releases](https://github.com/jflight-public/jesc-configurator/releases).
 
 ## Building (Chrome App)
 


### PR DESCRIPTION
If you describe how to install JESC Configurator, I'm pretty sure you don't want to link to the release page of the BLHeli Configurator.
If I'm wrong, I apologize and never mind! :-)